### PR TITLE
fix: remove unsupported autoDiscover field and bump to v0.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,14 +1,9 @@
 {
   "name": "unity-agentic-tools",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Token-efficient CLI tools for Unity YAML parsing, scene analysis, and prefab inspection via AI agents",
   "author": {
     "name": "taconotsandwich"
   },
-  "license": "Apache-2.0",
-  "autoDiscover": {
-    "commands": "../commands",
-    "skills": "../skills",
-    "agents": "../agents"
-  }
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Summary
- Remove unsupported `autoDiscover` field from plugin.json (Claude Code auto-discovers commands/, skills/, and agents/ directories automatically)
- Set version to 0.1.0 to reflect pre-release status

🤖 Generated with [Claude Code](https://claude.com/claude-code)