### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unity-file-tools"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance Unity YAML parser with napi-rs bindings"

--- a/rust-core/package.json
+++ b/rust-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-file-tools",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "High-performance Unity YAML parser - Rust native module",
   "main": "index.js",
   "types": "index.d.ts",

--- a/unity-agentic-tools/package.json
+++ b/unity-agentic-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unity-agentic-tools",
   "packageManager": "bun@latest",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Fast, token-efficient Unity YAML parser for AI agents",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0 to 0.2.0 across all package files
- Required because 0.1.0 was previously published and unpublished on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)