### PR TITLE
Fix command injection in docs command

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+# Sentinel's Journal - Critical Security Learnings
+
+## 2024-04-04 - Command Injection in `docs` query
+
+**Vulnerability:** Command Injection in the `docs` command of the CLI. The query string was being passed directly to a shell command through `child_process.exec`.
+
+**Learning:** `JSON.stringify()` is not sufficient for sanitizing user input passed to a shell. While it escapes double quotes, it does not prevent shell expansions like `$()` or backticks which are still interpreted within the resulting double-quoted string in many environments.
+
+**Prevention:** Always use `child_process.spawn` or `execFile` with an array of arguments to execute subprocesses. This bypasses the shell entirely and treats user input as literal text, preventing command injection.

--- a/unity-agentic-tools/src/cli.ts
+++ b/unity-agentic-tools/src/cli.ts
@@ -16,7 +16,7 @@ import { find_unity_project_root, glob_match, resolve_project_path } from './uti
 import { load_guid_cache } from './guid-cache';
 import * as path from 'path';
 import * as fs from 'fs';
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
 
 // Version is inlined at build time by bun's bundler (no runtime path resolution)
 const VERSION: string = (require('../package.json') as { version: string }).version;
@@ -280,17 +280,20 @@ program.command('docs <query>')
       globalArgs.push('--storage-path', storagePath);
     }
 
-    const args = [docIndexerPath, ...globalArgs, 'search', JSON.stringify(query)];
+    const args = [docIndexerPath, ...globalArgs, 'search', query];
     if (options.json) args.push('-j');
 
-    exec(`bun ${args.join(' ')}`, (error: unknown, stdout: string, stderr: string) => {
-      if (stderr) process.stderr.write(stderr);
-      if (error) {
-        console.error('Error:', (error as Error).message);
-        process.exit(1);
-      }
+    const child = spawn('bun', args, { stdio: 'inherit' });
 
-      console.log(stdout);
+    child.on('error', (error: Error) => {
+      console.error('Error:', error.message);
+      process.exit(1);
+    });
+
+    child.on('close', (code: number | null) => {
+      if (code !== 0) {
+        process.exit(code ?? 1);
+      }
     });
   });
 

--- a/unity-agentic-tools/src/cli.ts
+++ b/unity-agentic-tools/src/cli.ts
@@ -16,7 +16,7 @@ import { find_unity_project_root, glob_match, resolve_project_path } from './uti
 import { load_guid_cache } from './guid-cache';
 import * as path from 'path';
 import * as fs from 'fs';
-const { spawn } = require('child_process');
+import { spawn } from 'child_process';
 
 // Version is inlined at build time by bun's bundler (no runtime path resolution)
 const VERSION: string = (require('../package.json') as { version: string }).version;
@@ -283,6 +283,8 @@ program.command('docs <query>')
     const args = [docIndexerPath, ...globalArgs, 'search', query];
     if (options.json) args.push('-j');
 
+    // ✅ SAFE: Use spawn with an array of arguments to avoid shell command injection.
+    // Unlike exec(), spawn() does not invoke a shell, treating user input as literal text.
     const child = spawn('bun', args, { stdio: 'inherit' });
 
     child.on('error', (error: Error) => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command Injection in `unity-agentic-tools docs` command.
🎯 Impact: An attacker could execute arbitrary shell commands on the user's machine by providing a specially crafted query string like `$(touch pwned)`.
🔧 Fix: Switched from `child_process.exec` (which invokes a shell) to `child_process.spawn` (which executes the binary directly with an array of arguments). Removed insufficient `JSON.stringify` sanitization.
✅ Verification: Confirmed that normal queries like `Rigidbody` still work, while injection attempts like `$(touch ...)` or `; touch ...` are now treated as literal text and do not execute. Verified that pre-existing test failures were unrelated to this change.

---
*PR created automatically by Jules for task [5902071710027452778](https://jules.google.com/task/5902071710027452778) started by @taconotsandwich*